### PR TITLE
修复第一次通过 hash 进入页面的时候没有往 location2hash 放入当前的 hash

### DIFF
--- a/public/mmHistory.js
+++ b/public/mmHistory.js
@@ -142,7 +142,9 @@ define(["avalon"], function(avalon) {
                 if (this.basepath === location.href.replace(/\/$/, "")) {
                     execRouter("/")
                 } else if (location.href.indexOf("#!") !== -1) {
-                    execRouter(location.href.split("#!")[1])
+                    var hash = location.href.split("#!")[1]
+                    this.location2hash[ location.href ] = "#" + this.options.hashPrefix + "/" + hash.replace(rleftSlant, "")
+                    execRouter(hash)
                 }
             } else if (this.html5Mode === true && this.rbasepath.test(location.href)) {
                 execRouter(RegExp.rightContext)


### PR DESCRIPTION
我在chrome下调了一下mmHistory的代码（html5Mode = false），
发现直接通过 url#!/hash 进入页面的时候没有往 location2hash 放入当前的 hash，
因此进入该页面后点击前进到其他页面再直接通过浏览器返回键返回时在 location2hash 中找不到对应的 hash
