### PR TITLE
Update mmRouter.js

### DIFF
--- a/public/mmRouter.js
+++ b/public/mmRouter.js
@@ -89,6 +89,9 @@ define(["mmHistory"], function(avalon) {
     }
     function parseQuery(path) {
         var array = path.split("#"), query = {}, tail = array[1];
+        if(array.length==1 && array[0].indexOf('?')>-1){
+            tail = array[0], array[0] = array[0].split('?')[0];
+        }
         if (tail) {
             var index = tail.indexOf("?");
             if (index > 0) {


### PR DESCRIPTION
mmHistory.js 97行
            function execRouter(hash) {
                var router = avalon.router
                hash = hash.replace(rhashBang, "/")

假设有这样一个链接<a href="#/tpl2/?a=1&b=2&c=abc">tpl2</a>，用户点击后，
经过上面代码处理得到 hash = /tpl2/?a=1&b=2&c=abc

mmRequest.js 90行
    function parseQuery(path) {
        var array = path.split("#"), query = {}, tail = array[1];
        if (tail) {
            var index = tail.indexOf("?");

而到了mmRequest.js的90行，根据#来切割，再根据tail来切割query str,最后得到query object

显然，这里path已经没有#了，所以，tail为undefined，这样就得不到query str了。

所以我觉得这应该是个小问题
