### PR TITLE
截获点击事件时，如果a标签的href属性没有设置，获取到的是null，在执行replace时出错

### DIFF
--- a/mmHistory.js
+++ b/mmHistory.js
@@ -224,6 +224,9 @@ define(["avalon"], function(avalon) {
         if (targetIsThisWindow(target.target)) {
             var href = oldIE ? target.getAttribute("href", 2) : target.getAttribute("href") || target.getAttribute("xlink:href")
             var prefix = avalon.history.prefix
+            if (href === null) { // href is null if the attribute is not present
+                return
+            }
             var hash = href.replace(prefix, "").trim()
             if (href.indexOf(prefix) === 0 && hash !== "") {
                 event.preventDefault()


### PR DESCRIPTION
比如用 a 标签模拟按钮的时候不设置 href 就会在这里出错，不设置 href 的 a 标签一般不会有导航的作用，所以判断 href 为 null 就可以直接返回了
