### PR TITLE
bug fixed.

### DIFF
--- a/mmHistory.js
+++ b/mmHistory.js
@@ -136,20 +136,20 @@ define(["avalon"], function(avalon) {
                 if (that.monitorMode === "iframepoll" && !iframe) {
                     return false
                 }
-                var pageHash = that.getFragment(), hash
+                var pageHash = that.getFragment(), hash, lastHash = avalon.router.getLastPath()
                 if (iframe) {//IE67
                     var iframeHash = that.getHash(iframe)
                     //与当前页面hash不等于之前的页面hash，这主要是用户通过点击链接引发的
-                    if (pageHash !== that.fragment) {
+                    if (pageHash !== lastHash) {
                         that._setIframeHistory(that.prefix + pageHash)
                         hash = pageHash
                         //如果是后退按钮触发hash不一致
-                    } else if (iframeHash !== that.fragment) {
+                    } else if (iframeHash !== lastHash) {
                         that.location.hash = that.prefix + iframeHash
                         hash = iframeHash
                     }
 
-                } else if (pageHash !== that.fragment) {
+                } else if (pageHash !== lastHash) {
                     hash = pageHash
                 }
                 if (hash !== void 0) {


### PR DESCRIPTION
https://github.com/RubyLouvre/mmRouter/issues/62
表现在此。因为在判断hash是否变更时，that.fragment其实已经被更新，所以无法触发hashchange的处理函数