### PR TITLE
修正YUI无法压缩的bug

### DIFF
--- a/mmRouter.js
+++ b/mmRouter.js
@@ -224,7 +224,7 @@ define(["./mmHistory"], function() {
                 },
                 pattern: "0|1"
             },
-            int: {
+            'int': {
                 decode: function(val) {
                     return parseInt(val, 10);
                 },


### PR DESCRIPTION
在`Router.prototype.$types`使用了javascript保留字`int`作为属性名，导致YUI压缩抛出异常。