### PR TITLE
当url参数指明为string时，直接使用原始的字符串

### DIFF
--- a/mmRouter.js
+++ b/mmRouter.js
@@ -226,7 +226,10 @@ define(["./mmHistory"], function () {
                 }
             },
             string: {
-                pattern: "[^\\/]*"
+                pattern: "[^\\/]*",
+                decode: function(val){
+                	return val;
+                }
             },
             bool: {
                 decode: function (val) {


### PR DESCRIPTION
现在string没有指定decode函数，会JSON.parse来解析参数值。这可能会带来一些问题，比如javascript下64位long型的精度问题。

建议如果指定了是string类型，直接取原始的字符串值。如果需要JSON.parse，不指定参数的类型即可。